### PR TITLE
Add learning-resources.md in External Resources

### DIFF
--- a/External Resources/learning-resources.md
+++ b/External Resources/learning-resources.md
@@ -1,0 +1,11 @@
+## Learning Resources
+
+A simple reference of resources that members of D4D have found useful in learning some of the languages, platforms, libraries, and methods applicable to D4D projects.
+
+### Python
+* CheckiO - https://checkio.org/ - online game for Python coders
+* Enki - https://www.enki.com - mobile app with 5 minute "workouts" for multiple programming topics
+* Exercism - http://exercism.io/ - Download and solve practice problems in over 30 different languages
+
+### Git
+* Enki - https://www.enki.com - mobile app with 5 minute "workouts" for multiple programming topics


### PR DESCRIPTION
Add External Resources folder, which currently has two documents on roadmap:
1. `learning-resources.md` which is started with this PR, a document for member curated external resources for learning languages (Python, R), tools, methods, etc. related to D4D projects.
2. A document that will list useful/relevant Python modules for members to reference for use in D4D projects.